### PR TITLE
[DM-35881] Document user private groups and primary GIDs

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -250,15 +250,17 @@ This is called a user private group.
 The GID of this group is also the user's primary GID and should be their default group for services with POSIX file system access, such as the :ref:`Notebook Aspect <notebook-aspect>`.
 This allows Science Platform services to use the user's group membership for authorization decisions without separately tracking authorization rules by username, since access to a specific user can be done by granting access to that user's user private group (which will contain only that one member).
 
-Use of user private groups is not required.
-Deployments that use OpenID Connect with a local identity provider that doesn't provide user private groups may choose not to implement them.
-In those cases, the local identity provider should provide the user's primary GID via LDAP, since it otherwise won't be set.
-(Or, alternately, that deployment can avoid running any services, such as the Notebook Aspect, that require a primary GID.)
-
 For GitHub deployments, the user's account ID (used for their UID) is also used for the GID for their user private group.
 This risks a conflict, since the user account ID space is not distinct from the team ID space, which is used for the GIDs of all other groups.
 If a user's account ID happens to be the same number as a team ID, members of that team could have access to the user's group-accessible files, or the user may incorrectly have access to that team's files.
 We are currently ignoring this potential conflict on the grounds that, given the sizes of the spaces involved and the small number of users on GitHub deployments, it's unlikely to happen in practice.
+
+Use of user private groups is not required.
+Deployments that use OpenID Connect with a local identity provider that doesn't provide user private groups may choose not to implement them.
+If UIDs are allocated from LDAP and the UID space is not distinct from the GID space, it may be impossible to configure user private groups unless they are present in LDAP, since the only way Gafaelfawr supports sythesizing them is by creating a group with the same GID as the user's UID.
+
+Deployments with OpenID Connect do need to provide the user's primary GID via LDAP, whether or not that corresponds to a user private group.
+Otherwise, services that require a primary GID, such as the Notebook Aspect, will not work.
 
 Authentication flows
 ====================

--- a/index.rst
+++ b/index.rst
@@ -80,9 +80,10 @@ When federated identity is required, authentication is done via the OpenID Conne
 CILogon gives the user the option SAML authentication (used by most identity federations such as InCommon) or other identity providers such as GitHub and Google, and then communicates the resulting authentication information to Gafaelfawr with OpenID Connect.
 The other supported deployment options are an OAuth 2.0 authentication request to GitHub or an OpenID Connect authentication request to a local identity provider.
 
-Once the user has been authenticated, their identity must be associated with additional information: full name, email address, numeric UID, group membership, and numeric GIDs for the groups.
+Once the user has been authenticated, their identity must be associated with additional information: full name, email address, numeric UID, primary GID, group membership, and numeric GIDs for the groups.
 In deployments using federated identity, most of this data comes from :ref:`COmanage <comanage-idm>` (via LDAP), and numeric UIDs and GIDs come from :ref:`Firestore <firestore>`.
 For GitHub deployments, access to the user's profile and organization membership is requested as part of the OAuth 2.0 request, and then retrieved after authentication with the token obtained by the OAuth 2.0 authentication.  See :ref:`GitHub <github>` for more details.
+For federated identity and GitHub deployments, the primary GID is the user's user private group (see :ref:`User private groups <user-private-groups>`).
 With OpenID Connect, this information is either extracted from the claims of the JWT_ issued as a result of the OpenID Connect authentication flow, or is retrieved from LDAP.
 
 .. _JWT: https://datatracker.ietf.org/doc/html/rfc7519
@@ -238,6 +239,26 @@ Therefore, if the group name formed as above is longer than 32 characters, it wi
 The full group name will be hashed (with SHA-256) and truncated at 25 characters, and then a dash and the first six characters of the URL-safe-base64-encoded hash will be appended.
 
 The ``id`` attribute for each team will be used as the GID of the corresponding group.
+
+.. _user-private-groups:
+
+User private groups
+-------------------
+
+For federated identity and GitHub deployments, every user is automatically also a member (and the only member) of a group whose name matches the username and whose GID matches the user's UID.
+This is called a user private group.
+The GID of this group is also the user's primary GID and should be their default group for services with POSIX file system access, such as the :ref:`Notebook Aspect <notebook-aspect>`.
+This allows Science Platform services to use the user's group membership for authorization decisions without separately tracking authorization rules by username, since access to a specific user can be done by granting access to that user's user private group (which will contain only that one member).
+
+Use of user private groups is not required.
+Deployments that use OpenID Connect with a local identity provider that doesn't provide user private groups may choose not to implement them.
+In those cases, the local identity provider should provide the user's primary GID via LDAP, since it otherwise won't be set.
+(Or, alternately, that deployment can avoid running any services, such as the Notebook Aspect, that require a primary GID.)
+
+For GitHub deployments, the user's account ID (used for their UID) is also used for the GID for their user private group.
+This risks a conflict, since the user account ID space is not distinct from the team ID space, which is used for the GIDs of all other groups.
+If a user's account ID happens to be the same number as a team ID, members of that team could have access to the user's group-accessible files, or the user may incorrectly have access to that team's files.
+We are currently ignoring this potential conflict on the grounds that, given the sizes of the spaces involved and the small number of users on GitHub deployments, it's unlikely to happen in practice.
 
 Authentication flows
 ====================
@@ -624,6 +645,8 @@ The general pattern for protecting a service with authentication and access cont
 If the service needs information about the user, it obtains that from the ``X-Auth-Request-*`` headers that are set by Gafaelfawr via ingress-nginx.
 However, some Science Platform services require additional special attention.
 
+.. _notebook-aspect:
+
 Notebook Aspect
 ---------------
 
@@ -648,13 +671,17 @@ That provider runs inside the context of a request to JupyterHub that requires a
 It registers a custom route (``/gafaelfawr/login`` in the Hub's route namespace) and returns it as a login URL.
 That custom route reads the headers from the incoming request, which are set by Gafaelfawr, to find the delegated notebook token, and makes an API call to Gafaelfawr using that token for authentication to obtain the user's identity information.
 That identity information along with the token are then stored as the JupyterHub authentication session state.
-Information from the authentication session state is used when spawning a user lab to control the user's UID, groups, and other information required by the lab, and the notebook token is injected into the lab so that it will be available to the user.
+Information from the authentication session state is used when spawning a user lab to control the user's UID, GID, groups, and other information required by the lab, and the notebook token is injected into the lab so that it will be available to the user.
 
 .. figure:: /_static/flow-jupyter.svg
    :name: JupyterHub and lab authentication flow
 
    Sequence diagram of the authentication flow between Gafaelfawr, JupyterHub, and the lab.
    This diagram assumes the user is already authenticated to Gafaelfawr and therefore omits the flow to the external identity provider (see :ref:`Browser flows <browser-flows>`).
+
+The lab itself is spawned running with the UID and GID of the user, so that any accesses to mounted POSIX file systems are accessed as the identity of the user.
+JupyterHub therefore requires the UID and primary GID for users to be set, and cannot spawn pods for users that do not have that information.
+The GIDs of the user's other groups are added as supplemental groups for the lab process.
 
 Because JupyterHub has its own authentication session that has to be linked to the Gafaelfawr authentication session, there are a few wrinkles here that require special attention.
 
@@ -747,14 +774,17 @@ This information comes from OpenID Connect claims or from GitHub queries for inf
 - **name**: The user's preferred full name
 - **email**: The user's email address
 - **uid**: The user's unique numeric UID
+- **gid**: The user's primary GID
 - **groups**: The user's group membership as a list of dicts with two keys, **name** and **id** (the unique numeric GID of the group)
 
 If this data is set in Redis, that information is used by preference.
-If UID or GID information is not set in Redis and Firestore is configured (which is the case for deployments using CILogon and COmanage), those values are taken from Firestore.
+If UID or GID information is not set in Redis and Firestore is configured (which is the case for deployments using CILogon and COmanage), those values are taken from Firestore, and the user's primary GID is set to the same as their UID.
 For data not present in Redis or Firestore (if configured), LDAP is queried for the information.
 In other words, Gafaelfawr uses any data stored with the token in Redis by preference, then Firestore (if configured), then LDAP (if configured).
 
 If LDAP is not configured and no source of that data was found, that data element is empty, is not included in API responses, and is not set in the relevant HTTP header (if any).
+This may mean that some services will not function for that user.
+For example, the Notebook Aspect requires the UID and GID to be set.
 
 In CILogon and COmanage deployments, none of these fields are set during token creation.
 All data comes from Firestore or LDAP.


### PR DESCRIPTION
Add some explicit documentation of user private groups, since that
wasn't fleshed out very well.  Document that they may not be in use
for OpenID Connect deployments.  Document the new primary GID field
and mention that it's required for the Notebook Aspect.  Discuss how
UID and GID are used when spawning lab pods.