### PR TITLE
correct diagram caption to OIDC browser authentication flow

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -414,7 +414,7 @@ OpenID Connect
 Here is the OpenID Connect authentication flow in detail.
 
 .. mermaid:: flow-login-oidc.mmd
-   :caption: GitHub browser authentication flow
+   :caption: OIDC browser authentication flow
 
 This diagram omits the ingress, the initial unauthenticated redirect to ``/login``, and the service to which the user is sent once the login process is complete.
 All of those steps happen identically to the :ref:`generic browser flow <generic-browser-flow>`.


### PR DESCRIPTION
Updated the caption of the OpenID Connect authentication flow diagram - it seemed to be mis-captioned as the previous Github browser auth flow diagram.